### PR TITLE
Adapt to mongo-java-driver changes, so mongo-jackson-codec builds with mongo 3.0.4.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ apply plugin: 'maven-publish'
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
-def mongoVersion = '3.0.0-beta3'
+def mongoVersion = '3.0.4'
 
 group = 'fr.javatic.mongo'
 version = "${mongoVersion}__0.1"

--- a/src/main/java/fr/javatic/mongo/jacksonCodec/CodecRegistryFactory.java
+++ b/src/main/java/fr/javatic/mongo/jacksonCodec/CodecRegistryFactory.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.bson.codecs.BsonValueCodecProvider;
 import org.bson.codecs.ValueCodecProvider;
 import org.bson.codecs.configuration.CodecRegistry;
-import org.bson.codecs.configuration.CodecRegistryHelper;
+import org.bson.codecs.configuration.CodecRegistries;
 
 import java.util.Arrays;
 
@@ -29,7 +29,7 @@ public class CodecRegistryFactory {
     }
 
     public static CodecRegistry getDefaultCodecRegistry(ObjectMapper bsonObjectMapper) {
-        return CodecRegistryHelper.fromProviders(Arrays.asList(
+        return CodecRegistries.fromProviders(Arrays.asList(
             new ValueCodecProvider(),
             new BsonValueCodecProvider(),
             new ObjectCodecProvider(bsonObjectMapper)


### PR DESCRIPTION
Specifically, "Renamed CodecRegistryHelper to CodecRegistries." from
https://github.com/mongodb/mongo-java-driver/commit/5c0f4caef43d85a03efa48b99eafa3dead9c668a
